### PR TITLE
Use default junk fill weights when none are provided

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -129,11 +129,13 @@ class MZMWorld(World):
         self.locked_items = []
         self.pre_fill_items = []
         self.removed_items = []
+        if not self.options.junk_fill_weights.value:
+            self.options.junk_fill_weights.value = self.options.junk_fill_weights.default
         self.junk_fill_items = list(self.options.junk_fill_weights.value.keys())
         self.junk_fill_cdf = list(itertools.accumulate(self.options.junk_fill_weights.value.values()))
 
         if self.options.metroid_dna_available.value < self.options.metroid_dna_required.value:
-            self.options.metroid_dna_available = self.options.metroid_dna_required
+            self.options.metroid_dna_available.value = self.options.metroid_dna_required.value
 
         if self.options.layout_patches.value == LayoutPatches.option_true:
             self.enabled_layout_patches = list(LAYOUT_PATCH_MAPPING.keys())
@@ -352,7 +354,7 @@ class MZMWorld(World):
         }
 
     def get_filler_item_name(self) -> str:
-        return self.multiworld.random.choices(self.junk_fill_items, cum_weights=self.junk_fill_cdf)[0]
+        return self.random.choices(self.junk_fill_items, cum_weights=self.junk_fill_cdf)[0]
 
     def create_item(self, name: str, force_classification: Optional[ItemClassification] = None) -> MZMItem:
         if self.is_universal_tracker() and name == self.glitches_item_name:

--- a/options.py
+++ b/options.py
@@ -341,6 +341,7 @@ class JunkFillWeights(ItemDict):
     """
     Specify the distribution of extra capacity expansions that should be used to fill vacancies in the pool.
     This option only has any effect if there are unfilled locations, e.g. when some items are removed.
+    If no weights are provided, the defaults will be used.
     """
     display_name = "Junk Fill Weights"
     visibility = Visibility.template | Visibility.complex_ui | Visibility.spoiler


### PR DESCRIPTION
This prevents an `IndexError` being thrown by `random.choices()` if the user does not specify any `junk_fill_weights`

I also switched a reference from `multiworld.random` to `world.random` and fixed a reassignment of an option.